### PR TITLE
Feat: 회원가입 후 자동 로그인 기능 추가

### DIFF
--- a/src/pages/join/JoinPage.vue
+++ b/src/pages/join/JoinPage.vue
@@ -145,11 +145,16 @@ const join = async () => {
   try {
     isLoading.value = true;
     const createResponse = await auth.create(member);
-    // await auth.create(member);
     console.log('회원가입 요청:', member);
-    console.log('회원가입 응답:', createResponse); 
-    await auth.login({ memberId: member.memberId, password: member.password });
-    router.push({ name: 'home' });
+    console.log('회원가입 응답:', createResponse);
+
+		// 회원가입 후 로그인 요청
+    const loginResponse = await auth.login(member.memberId, member.password);
+
+    if (loginResponse) {
+      console.log('로그인 성공:', loginResponse);
+      router.push({ name: 'home' });
+    }
   } catch (error) {
     alert('회원가입 중 오류가 발생했습니다.');
     console.error('회원가입 중 오류:', error);


### PR DESCRIPTION
#️⃣연관된 이슈
[SCRUM-257]

📝작업 내용
1. 중복된 로그인 메서드 제거:
 - 기존 `login` 메서드 중복 제거, 하나의 로그인 메서드로 통합.

2. 로그인 프로세스 개선:
   - 로그인 시 `memberId`와 `password`를 매개변수로 받아 처리, 응답 데이터에서 `accessToken`, `refreshToken`을 로컬 스토리지에 저장.

3. 회원가입 후 자동 로그인:
   - 회원가입 후 자동으로 로그인 요청을 보내도록 수정.

4. 콘솔 로그 추가:
   - 로그인 시도 및 응답 데이터에 대한 콘솔 로그 추가.

5. 로컬 스토리지에서 인증 데이터 로드:
   - `loadAuthState` 메서드에서 로컬 스토리지의 인증 데이터를 기반으로 상태 초기화.



[SCRUM-257]: https://fingertips-mz.atlassian.net/browse/SCRUM-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ