### PR TITLE
Fix: 헤더 프로필 이미지 URL 조회 경로 수정

### DIFF
--- a/src/components/common/Header.vue
+++ b/src/components/common/Header.vue
@@ -15,6 +15,7 @@ const logout = async () => {
   localStorage.clear(); 
   router.push('/');
 };
+
 </script>
 
 <template>

--- a/src/components/common/Header.vue
+++ b/src/components/common/Header.vue
@@ -1,13 +1,15 @@
 <script setup>
 import { computed } from "vue";
 import { useAuthStore } from "@/stores/auth";
+import { useMemberStore } from '@/stores/member.js';
 import { useRouter } from "vue-router";
 
 const authStore = useAuthStore();
+const memberStore = useMemberStore();
 const router = useRouter();
 
 const memberId = computed(() => authStore.member.memberId);
-const imageUrl = computed(() => authStore.member.imageUrl);
+const imageUrl = computed(() => memberStore.member.imageUrl);
 
 const logout = async () => {
   await authStore.logout();
@@ -15,7 +17,6 @@ const logout = async () => {
   localStorage.clear(); 
   router.push('/');
 };
-
 </script>
 
 <template>

--- a/src/components/connection/AddAccountModal.vue
+++ b/src/components/connection/AddAccountModal.vue
@@ -99,7 +99,7 @@ watch(
               class="inline-flex items-center w-full p-5 my-1 bg-white border-2 border-gray-200 rounded-lg cursor-pointer peer-checked:border-indigo-900 hover:text-gray-600 peer-checked:text-gray-600 hover:bg-gray-50"
             >
               <img
-                :src="account.image"
+                :src="account.assetImage"
                 alt="account"
                 class="w-10 h-10 rounded-full mr-3"
               />

--- a/src/components/connection/AddAccountModal.vue
+++ b/src/components/connection/AddAccountModal.vue
@@ -105,9 +105,9 @@ watch(
               />
               <div class="block">
                 <div class="text-sm text-gray-600">
-                  {{ account.financeName }}
+                  {{ account.bankName }}
                 </div>
-                <div class="font-bold">{{ account.prdtName }}</div>
+                <div class="font-bold">{{ account.assetName }}</div>
               </div>
             </label>
           </div>

--- a/src/components/connection/AddCardModal.vue
+++ b/src/components/connection/AddCardModal.vue
@@ -100,8 +100,8 @@ watch(
             >
               <img :src="card.image" alt="card" class="h-10 rounded-sm mr-3" />
               <div class="block">
-                <div class="text-sm text-gray-600">{{ card.financeName }}</div>
-                <div class="font-bold">{{ card.prdtName }}</div>
+                <div class="text-sm text-gray-600">{{ card.bankName }}</div>
+                <div class="font-bold">{{ card.assetName }}</div>
               </div>
             </label>
           </div>

--- a/src/components/connection/AddCardModal.vue
+++ b/src/components/connection/AddCardModal.vue
@@ -98,7 +98,7 @@ watch(
               :for="'card-' + index"
               class="inline-flex items-center w-full p-5 my-1 bg-white border-2 border-gray-200 rounded-lg cursor-pointer peer-checked:border-indigo-900 hover:text-gray-600 peer-checked:text-gray-600 hover:bg-gray-50"
             >
-              <img :src="card.image" alt="card" class="h-10 rounded-sm mr-3" />
+              <img :src="card.assetImage" alt="card" class="h-10 rounded-sm mr-3" />
               <div class="block">
                 <div class="text-sm text-gray-600">{{ card.bankName }}</div>
                 <div class="font-bold">{{ card.assetName }}</div>

--- a/src/components/connection/ConnectedAccount.vue
+++ b/src/components/connection/ConnectedAccount.vue
@@ -34,9 +34,9 @@ const fetchAsset = async () => {
 };
 
 const disconnectAccount = async (accountIdx) => {
-  const account = connectedAccountList.value.find(account => account.prdtId === accountIdx);
+  const account = connectedAccountList.value.find(account => account.assetIdx === accountIdx);
   
-  const confirm = window.confirm(`${account.prdtName} 연동을 해제하시겠습니까?`);
+  const confirm = window.confirm(`${account.assetName} 연동을 해제하시겠습니까?`);
 
   if (confirm) {
     await assetStore.disconnectAccount(accountIdx);
@@ -79,11 +79,11 @@ onMounted(async () => {
           <div class="flex items-center">
             <img :src="account.image" alt="account" class="w-12 h-12 mr-4 rounded-full" />
             <div>
-              <div class="text-medium">{{ account.prdtName }}</div>
-              <div class="text-lg font-bold">{{ account.balance.toLocaleString() }}원</div>
+              <div class="text-medium">{{ account.assetName }}</div>
+              <div class="text-lg font-bold">{{ account.accountBalance.toLocaleString() }}원</div>
             </div>
           </div>
-          <button @click="disconnectAccount(account.prdtId)" class="ml-4 text-gray-400">
+          <button @click="disconnectAccount(account.assetIdx)" class="ml-4 text-gray-400">
             삭제
           </button>
         </div>

--- a/src/components/connection/ConnectedAccount.vue
+++ b/src/components/connection/ConnectedAccount.vue
@@ -77,7 +77,7 @@ onMounted(async () => {
       <div v-else-if="connectedAccountList.length > 0">
         <div v-for="(account, index) in connectedAccountList" :key="index" class="py-3 pl-2 flex items-center justify-between">
           <div class="flex items-center">
-            <img :src="account.image" alt="account" class="w-12 h-12 mr-4 rounded-full" />
+            <img :src="account.assetImage" alt="account" class="w-12 h-12 mr-4 rounded-full" />
             <div>
               <div class="text-medium">{{ account.assetName }}</div>
               <div class="text-lg font-bold">{{ account.accountBalance.toLocaleString() }}원</div>

--- a/src/components/connection/ConnectedCard.vue
+++ b/src/components/connection/ConnectedCard.vue
@@ -94,7 +94,7 @@ onMounted(async () => {
           class="py-3 pl-2 flex items-center justify-between"
         >
           <div class="flex items-center">
-            <img :src="card.image" alt="card" class="h-12 mr-4 rounded-sm" />
+            <img :src="card.assetImage" alt="card" class="h-12 mr-4 rounded-sm" />
             <div>
               <div class="text-medium">{{ card.assetName }}</div>
               <div class="text-lg font-bold">

--- a/src/components/connection/ConnectedCard.vue
+++ b/src/components/connection/ConnectedCard.vue
@@ -34,7 +34,7 @@ const fetchAsset = async () => {
   );
 
   connectedCardList.value.forEach((card) => {
-    const cardIdx = card.prdtId;
+    const cardIdx = card.assetIdx;
     if (cardTransactionStore.cardAmountBycardIdx[cardIdx]) {
       card.totalAmount = cardTransactionStore.cardAmountBycardIdx[cardIdx];
     } else {
@@ -46,9 +46,9 @@ const fetchAsset = async () => {
 };
 
 const disconnectCard = async (cardIdx) => {
-  const card = connectedCardList.value.find((card) => card.prdtId === cardIdx);
+  const card = connectedCardList.value.find((card) => card.assetIdx === cardIdx);
 
-  const confirm = window.confirm(`${card.prdtName} 연동을 해제하시겠습니까?`);
+  const confirm = window.confirm(`${card.assetName} 연동을 해제하시겠습니까?`);
 
   if (confirm) {
     await assetStore.disconnectCard(cardIdx);
@@ -96,14 +96,14 @@ onMounted(async () => {
           <div class="flex items-center">
             <img :src="card.image" alt="card" class="h-12 mr-4 rounded-sm" />
             <div>
-              <div class="text-medium">{{ card.prdtName }}</div>
+              <div class="text-medium">{{ card.assetName }}</div>
               <div class="text-lg font-bold">
-                {{ card.totalAmount.toLocaleString() }}원
+                {{ card.totalCardExpense.toLocaleString() }}원
               </div>
             </div>
           </div>
           <button
-            @click="disconnectCard(card.prdtId)"
+            @click="disconnectCard(card.assetIdx)"
             class="ml-4 text-gray-400"
           >
             삭제

--- a/src/components/home/SBTIResult.vue
+++ b/src/components/home/SBTIResult.vue
@@ -19,9 +19,9 @@ const fetchSBTIResult = async (memberIdx) => {
   const _obj = toRaw(SBTIResult.value);
 
   if (_obj && _obj.typeImage) {
-    resultImage.value = `https://fingertips-bucket-local.s3.ap-northeast-2.amazonaws.com/${_obj.typeImage}`;
+    resultImage.value = `https://fingertips-bucket-local.s3.ap-northeast-2.amazonaws.com/basic-image/${_obj.typeImage}`;
   } else {
-    resultImage.value = `https://fingertips-bucket-local.s3.ap-northeast-2.amazonaws.com/before_test.png`;
+    resultImage.value = `https://fingertips-bucket-local.s3.ap-northeast-2.amazonaws.com/basic-image/before_test.png`;
     GoTest.value = true;
   }
 };

--- a/src/pages/login/LoginPage.vue
+++ b/src/pages/login/LoginPage.vue
@@ -1,11 +1,13 @@
 <script setup>
-import { computed, reactive, ref } from "vue";
+import { reactive, ref } from "vue";
 import { useAuthStore } from "@/stores/auth";
+import { useMemberStore } from '@/stores/member.js';
 import { useRouter } from "vue-router";
 import GoogleLoginComponent from "@/components/Login/GoogleLoginComponent.vue";
 
 const router = useRouter();
 const auth = useAuthStore();
+const memberStore = useMemberStore();
 
 const member = reactive({
   memberId: "",
@@ -31,6 +33,7 @@ const login = async () => {
       if (response.data.role === 'ROLE_ADMIN') {
         router.push("/admin");
       } else {
+        await memberStore.getProfile();
         router.push("/");
       }
     } else {

--- a/src/pages/mypage/MyPage.vue
+++ b/src/pages/mypage/MyPage.vue
@@ -243,6 +243,7 @@ const uploadImage = async (event) => {
       alert('이미지 업로드에 성공했습니다.');
       const imageUrl = `https://fingertips-bucket-local.s3.ap-northeast-2.amazonaws.com/${response.data.data.storeFileName}`;
       profile.imageUrl = imageUrl;
+     
       authStore.updateImageUrl(response.data.data.storeFileName)
       Object.assign(profile, { imageUrl: imageUrl });
       await fetchProfile();
@@ -267,8 +268,8 @@ const deleteImage = async (profileImage) => {
         },
       });
       if (response.data.success) {
-        profile.imageUrl = 'basic.jpg';
-        authStore.updateImageUrl("basic.jpg")
+        profile.imageUrl = 'upload-image/basic.jpg';
+        authStore.updateImageUrl("upload-image/basic.jpg")
         await fetchProfile();
       }
     } catch (error) {

--- a/src/stores/account-transaction.js
+++ b/src/stores/account-transaction.js
@@ -10,10 +10,10 @@ export const useAccountTransactionStore = defineStore('accountTransaction', {
   }),
 
   actions: {
-    async getAccountTransactionList(memberIdx) {
+    async getAccountTransactionList() {
       try {
         const authStore = useAuthStore();
-        const res = await apiInstance.get(`/transaction/account/${memberIdx}`, {
+        const res = await apiInstance.get(`/asset/account/`, {
           headers: {
             Authorization: authStore.member.accessToken,
           },

--- a/src/stores/asset.js
+++ b/src/stores/asset.js
@@ -21,10 +21,10 @@ export const useAssetStore = defineStore("asset", {
         });
         this.allAssetList = response.data.data;
         this.allAccountList = this.allAssetList.filter(
-          (asset) => asset.financeKind === 2
+          (asset) => asset.assetType === 'account'
         );
         this.allCardList = this.allAssetList.filter(
-          (asset) => asset.financeKind === 1
+          (asset) => asset.assetType === 'card'
         );
         this.connectedAccountList = this.allAccountList.filter(
           (asset) => asset.connectedStatus === 1
@@ -39,7 +39,7 @@ export const useAssetStore = defineStore("asset", {
 
     async updateAccountStatus(selectedAccount) {
       try {
-        const accountIdx = selectedAccount.prdtId;
+        const accountIdx = selectedAccount.assetIdx;
         const authStore = useAuthStore();
         const response = await apiInstance.post(
           `/asset/account/${accountIdx}`,
@@ -59,7 +59,7 @@ export const useAssetStore = defineStore("asset", {
 
     async updateCardStatus(selectedCard) {
       try {
-        const cardIdx = selectedCard.prdtId;
+        const cardIdx = selectedCard.assetIdx;
         const authStore = useAuthStore();
         const response = await apiInstance.post(
           `/asset/card/${cardIdx}`,

--- a/src/stores/card-transaction.js
+++ b/src/stores/card-transaction.js
@@ -11,10 +11,10 @@ export const useCardTransactionStore = defineStore('cardTransaction', {
   }),
 
   actions: {
-    async getCardTransactionList(memberIdx) {
+    async getCardTransactionList() {
       try {
         const authStore = useAuthStore();
-        const res = await apiInstance.get(`/transaction/card/${memberIdx}`, {
+        const res = await apiInstance.get(`/asset/card/`, {
           headers: {
             Authorization: authStore.member.accessToken,
           },

--- a/src/stores/test.js
+++ b/src/stores/test.js
@@ -87,7 +87,8 @@ export const useTestStore = defineStore("testStore", {
     async getSurveyInfo() {
       try {
         const authStore = useAuthStore();
-        const response = await apiInstance.get(`/test/survey`, {
+        const response = await apiInstance.get("/test/survey", {
+          headers: {
             Authorization: authStore.member.accessToken,
           },
         });
@@ -261,6 +262,7 @@ export const useTestStore = defineStore("testStore", {
   getOptionsByQuestionIdx(questionIdx) {
     return this.options.get(questionIdx) || [];
   },
+
   resetScore() {
     this.impulseScore = 0;
     this.plannedScore = 0;


### PR DESCRIPTION
### 📝작업 내용
- 도하: 연결된 자산 페이지 수정
- 도하: 소비 성향 테스트 이미지 URL 변경
- 로그인 후 memberStore의 getProfile 함수 호출하며 이미지 URL 저장
- authStore -> memberStore에서 이미지 URL 조회하도록 수정
